### PR TITLE
Fixed Config Flow

### DIFF
--- a/custom_components/ripple_energy_api/manifest.json
+++ b/custom_components/ripple_energy_api/manifest.json
@@ -7,7 +7,7 @@
     "requirements": [],
     "dependencies": [],
     "codeowners": ["@mjp-76"],
-    "integration_type": "entity",
+    "integration_type": "hub",
     "iot_class": "cloud_polling",
     "config_flow": true
   }


### PR DESCRIPTION
Changed `"integration_type": "entity",` to `"integration_type": "hub",` allows for the config_flow to appear.
Unable to test any further, but it's asking for an API key now.

Addresses #1 